### PR TITLE
Add debug & dry-mode flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.php_cs.cache

--- a/Readme.md
+++ b/Readme.md
@@ -28,6 +28,8 @@ Options:
       --metadata-json=METADATA-JSON  Path to Json file containing details of product
       --archive=ARCHIVE              Path to the archive to upload
       --update-type=UPDATE-TYPE      Type of upgrade (Minor update / Major / new) [default: "updatemin"]
+      --debug                        Display additional details
+      --dry-run                      Display actions to do without actually running them
 ```
 
 Note `--metadata-json` and `--archive` needs to be valid paths to your files.

--- a/src/Client/MarketplaceClient.php
+++ b/src/Client/MarketplaceClient.php
@@ -9,6 +9,8 @@ use Psr\Http\Message\ResponseInterface;
 
 class MarketplaceClient
 {
+    const MARKETPLACE_URL = 'https://addons.prestashop.com/request/index.php';
+
     /**
      * @var Client
      */
@@ -18,7 +20,7 @@ class MarketplaceClient
     {
         $this->client = new Client(
             [
-                'base_uri' => 'https://addons.prestashop.com/request/index.php',
+                'base_uri' => self::MARKETPLACE_URL,
                 'headers' => ['api-key' => $apiKey],
             ]
         );


### PR DESCRIPTION
The flags `debug` and `dry-run` will allow us to display more information to the user before (or instead) sending the data to the marketplace.

